### PR TITLE
README: login data no longer a multi-line file starting with [login.ubuntu.com].

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ $ snapcraft export-login --snaps=PACKAGE_NAME \
       exported.txt
 ```
 
-This will produce a file `exported.txt` containing the login data,
-which should be a multi-line file starting with `[login.ubuntu.com]`.
+This will produce a file `exported.txt` containing the login data.
 The credentials can be restricted further with the `--channels` and
 `--expires` arguments if desired.
 


### PR DESCRIPTION
Related to https://github.com/snapcore/action-publish/issues/28, the login data produced by using `snapcraft export-login` is no longer a multi-line file starting with `[login.ubuntu.com]`. Users following the README may be confused if they are expecting that.